### PR TITLE
feat: floor plan parser via Claude Vision

### DIFF
--- a/app/api/parse-floorplan/route.ts
+++ b/app/api/parse-floorplan/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+const MAX_SIZE = 10 * 1024 * 1024;
+
+type SupportedMediaType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+function sniffImageFormat(buf: Buffer): { mediaType: SupportedMediaType } | { error: string } {
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return { mediaType: "image/jpeg" };
+  }
+  if (
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a
+  ) {
+    return { mediaType: "image/png" };
+  }
+  if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38) {
+    return { mediaType: "image/gif" };
+  }
+  if (
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) {
+    return { mediaType: "image/webp" };
+  }
+
+  // Detect common unsupported formats for a helpful hint
+  let detectedHint = "unknown binary data";
+  if (buf.length >= 12) {
+    const ftyp = buf.slice(4, 12).toString("ascii");
+    if (ftyp.startsWith("ftypavif")) detectedHint = "AVIF";
+    else if (ftyp.startsWith("ftypheic") || ftyp.startsWith("ftypmif1") || ftyp.startsWith("ftypmsf1")) detectedHint = "HEIC";
+  }
+
+  const isMobileLikely = detectedHint === "HEIC" || detectedHint === "AVIF";
+  const explainer = isMobileLikely
+    ? ` ${detectedHint} files often come from iPhones, newer Android phones, or websites that auto-serve modern formats — and the file extension can still say .jpg or .jpeg even though the actual image is ${detectedHint}. To convert: open it in Preview (macOS) or Photos and export as PNG or JPEG, or take a screenshot of the image (Cmd+Shift+4 on Mac).`
+    : " A file with a .jpg or .jpeg extension isn't always actually a JPEG — re-saving as PNG or JPEG from your image viewer usually fixes this.";
+
+  return {
+    error: `This image format isn't supported. Please upload a JPEG, PNG, GIF, or WebP. (Detected: ${detectedHint}.)${explainer}`,
+  };
+}
+
+type Room = {
+  name: string;
+  approxWidthFt: number | null;
+  approxLengthFt: number | null;
+  notes?: string;
+};
+
+type ParsedFloorPlan = {
+  rooms: Room[];
+  totalApproxSqFt: number | null;
+  scaleFound: boolean;
+  warnings: string[];
+};
+
+const SYSTEM_PROMPT = `You are a floor plan analyser. Respond with ONLY a valid JSON object — no markdown fences, no prose. The object must match this TypeScript type exactly:
+
+{
+  rooms: Array<{
+    name: string;               // lowercase, e.g. "living room", "bedroom 1"
+    approxWidthFt: number | null;   // best-guess feet; null if not determinable
+    approxLengthFt: number | null;
+    notes?: string;             // optional uncertainty notes
+  }>;
+  totalApproxSqFt: number | null;  // overall area estimate; null if unknown
+  scaleFound: boolean;              // true if dimension labels or a scale bar are visible
+  warnings: string[];               // always include "no scale visible" when scaleFound is false
+}`;
+
+export async function POST(req: NextRequest) {
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid multipart request." }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided." }, { status: 400 });
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json(
+      { error: "File exceeds the 10 MB limit." },
+      { status: 413 }
+    );
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const sniffed = sniffImageFormat(buffer);
+  if ("error" in sniffed) {
+    return NextResponse.json({ error: sniffed.error }, { status: 415 });
+  }
+  const base64 = buffer.toString("base64");
+  const mediaType = sniffed.mediaType;
+
+  const client = new Anthropic();
+
+  let message: Anthropic.Message;
+  try {
+    message = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: mediaType,
+                data: base64,
+              },
+            },
+            {
+              type: "text",
+              text: "Parse this floor plan and return the JSON object.",
+            },
+          ],
+        },
+      ],
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Claude API call failed.";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  const raw = message.content[0];
+  if (raw.type !== "text") {
+    return NextResponse.json(
+      { error: "Unexpected response format from Claude." },
+      { status: 502 }
+    );
+  }
+
+  let parsed: ParsedFloorPlan;
+  try {
+    const text = raw.text
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```\s*$/i, "")
+      .trim();
+    parsed = JSON.parse(text);
+  } catch {
+    return NextResponse.json(
+      { error: "Claude returned non-JSON output. Please try again." },
+      { status: 422 }
+    );
+  }
+
+  return NextResponse.json(parsed);
+}

--- a/app/components/FloorPlanUploader.tsx
+++ b/app/components/FloorPlanUploader.tsx
@@ -8,23 +8,64 @@ type UploadedFile = {
   url: string;
 };
 
-const ACCEPTED = ["image/png", "image/jpeg", "application/pdf"];
-const ACCEPT_ATTR = ".png,.jpg,.jpeg,.pdf";
+type Room = {
+  name: string;
+  approxWidthFt: number | null;
+  approxLengthFt: number | null;
+  notes?: string;
+};
+
+type ParsedFloorPlan = {
+  rooms: Room[];
+  totalApproxSqFt: number | null;
+  scaleFound: boolean;
+  warnings: string[];
+};
+
+const ACCEPTED = ["image/png", "image/jpeg"];
+const ACCEPT_ATTR = ".png,.jpg,.jpeg";
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 export default function FloorPlanUploader() {
   const [file, setFile] = useState<UploadedFile | null>(null);
   const [dragging, setDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [parsing, setParsing] = useState(false);
+  const [parseResult, setParseResult] = useState<ParsedFloorPlan | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const process = useCallback((raw: File) => {
+  const process = useCallback(async (raw: File) => {
     if (!ACCEPTED.includes(raw.type)) {
-      setError("Only PNG, JPG, and PDF files are supported.");
+      setError("Only PNG and JPG files are supported.");
+      return;
+    }
+    if (raw.size > MAX_FILE_SIZE) {
+      setError("File exceeds the 10 MB limit.");
       return;
     }
     setError(null);
+    setParseResult(null);
+    setParseError(null);
     const url = URL.createObjectURL(raw);
     setFile({ name: raw.name, type: raw.type, url });
+
+    setParsing(true);
+    try {
+      const form = new FormData();
+      form.append("file", raw);
+      const res = await fetch("/api/parse-floorplan", { method: "POST", body: form });
+      const json = await res.json();
+      if (!res.ok) {
+        setParseError(json.error ?? "An unexpected error occurred.");
+      } else {
+        setParseResult(json as ParsedFloorPlan);
+      }
+    } catch {
+      setParseError("Network error — could not reach the server.");
+    } finally {
+      setParsing(false);
+    }
   }, []);
 
   const onDragOver = (e: React.DragEvent) => {
@@ -50,10 +91,11 @@ export default function FloorPlanUploader() {
     if (file) URL.revokeObjectURL(file.url);
     setFile(null);
     setError(null);
+    setParseResult(null);
+    setParseError(null);
+    setParsing(false);
     if (inputRef.current) inputRef.current.value = "";
   };
-
-  const isImage = file && (file.type === "image/png" || file.type === "image/jpeg");
 
   return (
     <div className="w-full max-w-2xl">
@@ -91,7 +133,7 @@ export default function FloorPlanUploader() {
             <p className="mt-1 text-sm text-zinc-500">
               or <span className="text-blue-600 underline">click to browse</span>
             </p>
-            <p className="mt-3 text-xs text-zinc-400">PNG, JPG, or PDF — max 20 MB</p>
+            <p className="mt-3 text-xs text-zinc-400">PNG or JPG — max 10 MB</p>
           </div>
           <input
             ref={inputRef}
@@ -112,31 +154,94 @@ export default function FloorPlanUploader() {
               Remove
             </button>
           </div>
-          {isImage ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={file.url}
-              alt="Floor plan preview"
-              className="w-full rounded-xl object-contain max-h-[480px] bg-zinc-50"
-            />
-          ) : (
-            <div className="flex flex-col items-center justify-center gap-3 rounded-xl bg-zinc-50 py-12">
+
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={file.url}
+            alt="Floor plan preview"
+            className="w-full rounded-xl object-contain max-h-[480px] bg-zinc-50"
+          />
+
+          {parsing && (
+            <div className="mt-6 flex items-center gap-2 text-sm text-zinc-500">
               <svg
+                className="animate-spin h-4 w-4 shrink-0"
                 xmlns="http://www.w3.org/2000/svg"
-                className="h-12 w-12 text-red-400"
                 fill="none"
                 viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
               >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
                 <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                 />
               </svg>
-              <p className="text-sm font-medium text-zinc-600">PDF uploaded</p>
-              <p className="text-xs text-zinc-400">{file.name}</p>
+              Analysing floor plan…
+            </div>
+          )}
+
+          {parseError && (
+            <p className="mt-4 text-sm text-red-600">{parseError}</p>
+          )}
+
+          {parseResult && (
+            <div className="mt-6 space-y-4">
+              {parseResult.warnings.length > 0 && (
+                <div className="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-800">
+                  <p className="mb-1 font-medium">Warnings</p>
+                  <ul className="list-inside list-disc space-y-0.5">
+                    {parseResult.warnings.map((w, i) => (
+                      <li key={i}>{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div>
+                <h3 className="mb-2 text-sm font-semibold text-zinc-700">Rooms</h3>
+                <div className="space-y-1.5">
+                  {[...parseResult.rooms]
+                    .sort((a, b) => {
+                      const aKnown = a.approxWidthFt != null && a.approxLengthFt != null;
+                      const bKnown = b.approxWidthFt != null && b.approxLengthFt != null;
+                      if (aKnown && !bKnown) return -1;
+                      if (!aKnown && bKnown) return 1;
+                      return 0;
+                    })
+                    .map((room, i) => (
+                      <div
+                        key={i}
+                        className="flex items-start justify-between rounded-lg bg-zinc-50 px-4 py-2 text-sm"
+                      >
+                        <div>
+                          <span className="font-medium capitalize text-zinc-700">{room.name}</span>
+                          {room.notes && (
+                            <p className="mt-0.5 text-xs text-zinc-400">{room.notes}</p>
+                          )}
+                        </div>
+                        <span className="ml-4 shrink-0 text-zinc-500">
+                          {room.approxWidthFt != null && room.approxLengthFt != null
+                            ? `${room.approxWidthFt} × ${room.approxLengthFt} ft`
+                            : "dimensions unknown"}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+
+              {parseResult.totalApproxSqFt != null && (
+                <p className="text-sm text-zinc-600">
+                  Total: ~{parseResult.totalApproxSqFt.toLocaleString()} sq ft
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "apartment-fit",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.93.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -32,6 +33,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
+      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1162,6 +1192,19 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -1716,6 +1759,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.93.0",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
Closes #2

   - POST /api/parse-floorplan calls Claude Sonnet vision and returns parsed JSON
   - Magic-byte sniff for media_type (rejects HEIC/AVIF with a helpful error)
   - Uploader posts on file select, shows rooms + warnings
   - Rooms with known dimensions sorted to top