### PR TITLE
feat: furniture URL handler with JSON-LD + SPA-state extraction (#3)

### DIFF
--- a/app/api/parse-furniture/route.ts
+++ b/app/api/parse-furniture/route.ts
@@ -1,0 +1,327 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+type FurnitureSize = {
+  label: string;
+  widthIn: number | null;
+  depthIn: number | null;
+  heightIn: number | null;
+};
+
+type ParsedFurniture = {
+  name: string;
+  category: string;
+  sizes: FurnitureSize[];
+  defaultSizeIndex: number;
+  colorOrFinish?: string;
+  material?: string;
+  sourceUrl: string;
+  warnings: string[];
+};
+
+const SYSTEM_PROMPT = `You are a furniture data extractor. You will be given either structured JSON-LD product data or the HTML body of a furniture product page. Extract the data and respond with ONLY the JSON object described below.
+
+CRITICAL: Never invent or infer dimensions. If the provided content does not contain explicit dimension numbers (width, depth, height in inches or cm), set those fields to null and add the warning "Dimensions not visible in page content — verify on the product page". Do NOT use prior knowledge of furniture brands or models to fill in dimensions. Only report numbers that are LITERALLY present in the input text.
+
+Many furniture pages list multiple available sizes (different lengths, modular configurations, etc.). Capture EVERY size variant you can find in the sizes array. If the URL contains a specific variant query param or the page indicates a default selection, use that index for defaultSizeIndex. Do not collapse multiple sizes into one entry. Respond with ONLY a valid JSON object — no markdown fences, no prose.
+
+The object must match this TypeScript type exactly:
+
+type FurnitureSize = {
+  label: string;          // e.g. "Standard (63 in)", "Small", "75 in / 191 cm"
+  widthIn: number | null;
+  depthIn: number | null;
+  heightIn: number | null;
+};
+
+type ParsedFurniture = {
+  name: string;
+  category: string;          // "sofa", "bed", "desk", "chair", "table", "shelving", "other"
+  sizes: FurnitureSize[];    // ALWAYS at least one entry, even if the page shows only one size
+  defaultSizeIndex: number;  // index into sizes[]; the size the URL or page treats as primary, 0 if unclear
+  colorOrFinish?: string;
+  material?: string;
+  sourceUrl: string;         // echo back the input URL
+  warnings: string[];        // e.g. "Dimensions not visible in page content — verify on the product page", "Multiple finish options exist", "page required login", "Amazon variants may be incomplete — verify on the product page"
+};
+
+For IKEA listings: structured dimension data is usually in the product details section — parse it carefully.
+For Amazon listings: add a warning "Amazon variants may be incomplete — verify on the product page" when you cannot see all size/configuration options.
+
+Convert all dimensions to inches yourself — do not call any tools. If a page lists dimensions in cm only, divide by 2.54 and round to one decimal place. Inches values can be approximate; users care about whether furniture fits, not millimeter precision.`;
+
+function isValidHttpsUrl(s: string): boolean {
+  try {
+    const u = new URL(s);
+    return u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isProductJsonLd(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  if (Array.isArray(data)) return data.some(isProductJsonLd);
+  const obj = data as Record<string, unknown>;
+  const t = obj["@type"];
+  return t === "Product" || (Array.isArray(t) && t.includes("Product"));
+}
+
+function extractJsonLd(html: string): string | null {
+  const results: object[] = [];
+  const re = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(m[1]);
+      if (isProductJsonLd(parsed)) results.push(parsed);
+    } catch {
+      // skip malformed blocks
+    }
+  }
+  if (results.length === 0) return null;
+  return JSON.stringify(results.length === 1 ? results[0] : results, null, 2).slice(0, 20_000);
+}
+
+function extractSpaState(html: string): string | null {
+  const chunks: string[] = [];
+  let m: RegExpExecArray | null;
+
+  // <script id="__NEXT_DATA__" type="application/json">
+  const nextDataRe = /<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/gi;
+  while ((m = nextDataRe.exec(html)) !== null) {
+    if (m[1].trim()) chunks.push(m[1].trim());
+  }
+
+  // window.__APOLLO_STATE__, window.__INITIAL_STATE__, window.__PRELOADED_STATE__
+  const windowStateRe = /<script[^>]*>([\s\S]*?window\.(?:__APOLLO_STATE__|__INITIAL_STATE__|__PRELOADED_STATE__)[\s\S]*?)<\/script>/gi;
+  while ((m = windowStateRe.exec(html)) !== null) {
+    if (m[1].trim()) chunks.push(m[1].trim());
+  }
+
+  // <script id="...-data" type="application/json"> (id before type)
+  const genericDataRe = /<script[^>]+id=["'][^"']*-data["'][^>]+type=["']application\/json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  while ((m = genericDataRe.exec(html)) !== null) {
+    if (m[1].trim()) chunks.push(m[1].trim());
+  }
+  // (type before id)
+  const genericDataRe2 = /<script[^>]+type=["']application\/json["'][^>]+id=["'][^"']*-data["'][^>]*>([\s\S]*?)<\/script>/gi;
+  while ((m = genericDataRe2.exec(html)) !== null) {
+    if (m[1].trim()) chunks.push(m[1].trim());
+  }
+
+  if (chunks.length === 0) return null;
+  return chunks.join("\n\n").slice(0, 60_000);
+}
+
+function cleanHtmlBody(html: string): string {
+  let cleaned = html
+    .replace(/<head[\s\S]*?<\/head>/gi, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, "")
+    .replace(/<svg[\s\S]*?<\/svg>/gi, "")
+    .replace(/<nav[\s\S]*?<\/nav>/gi, "")
+    .replace(/<header[\s\S]*?<\/header>/gi, "")
+    .replace(/<footer[\s\S]*?<\/footer>/gi, "")
+    .replace(/<!--[\s\S]*?-->/g, "");
+
+  const mainMatch = cleaned.match(/<main[\s\S]*?<\/main>/i);
+  if (mainMatch) {
+    cleaned = mainMatch[0];
+  } else {
+    const bodyMatch = cleaned.match(/<body[\s\S]*?<\/body>/i);
+    if (bodyMatch) cleaned = bodyMatch[0];
+  }
+
+  return cleaned.replace(/\s{2,}/g, " ").trim().slice(0, 40_000);
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const rawUrl =
+    typeof body === "object" &&
+    body !== null &&
+    "url" in body &&
+    typeof (body as Record<string, unknown>).url === "string"
+      ? ((body as Record<string, unknown>).url as string).trim()
+      : null;
+
+  if (!rawUrl) {
+    return NextResponse.json(
+      { error: "Missing or invalid 'url' field. Expected { url: string }." },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidHttpsUrl(rawUrl)) {
+    return NextResponse.json(
+      {
+        error:
+          "URL must use HTTPS. http://, file://, javascript:, and other schemes are not accepted.",
+      },
+      { status: 400 }
+    );
+  }
+
+  console.log("[parse-furniture] starting", rawUrl);
+
+  // Fetch the page server-side
+  let claudeInput: string;
+  try {
+    const fetchController = new AbortController();
+    const fetchTimeout = setTimeout(() => fetchController.abort(), 15_000);
+    const t0 = Date.now();
+
+    let response: Response;
+    try {
+      response = await fetch(rawUrl, {
+        signal: fetchController.signal,
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        },
+      });
+    } finally {
+      clearTimeout(fetchTimeout);
+    }
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `The product page returned ${response.status}. Try a different URL.` },
+        { status: 502 }
+      );
+    }
+
+    const html = await response.text();
+    const ms = Date.now() - t0;
+
+    const jsonLd = extractJsonLd(html);
+    const spaState = jsonLd ? null : extractSpaState(html);
+    const tier: "json-ld" | "spa-state" | "html-body" = jsonLd
+      ? "json-ld"
+      : spaState
+      ? "spa-state"
+      : "html-body";
+
+    if (tier === "json-ld") {
+      claudeInput = `Here is the page's structured product data (Schema.org JSON-LD):\n\n${jsonLd}\n\nThe URL was: ${rawUrl}`;
+    } else if (tier === "spa-state") {
+      claudeInput = `You will be given the raw initial-state JSON dumps embedded in a Next.js / Apollo / Redux SPA. Find product dimensions, name, sizes, and category by searching this JSON. Dimensions may be in inches, cm, or both — convert to inches. Many fields will be irrelevant — only extract product info.\n\nThe URL was: ${rawUrl}\n\n--- SPA STATE ---\n${spaState}`;
+    } else {
+      claudeInput = `Extract furniture data from this product page HTML and return ONLY the JSON object described in the system prompt. The page URL was: ${rawUrl}\n\n--- HTML ---\n${cleanHtmlBody(html)}`;
+    }
+    console.log("[parse-furniture] fetched in", ms, "ms, using:", tier, "input chars:", claudeInput.length);
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return NextResponse.json(
+        { error: "Could not fetch the URL. The site may block server-side requests or be down." },
+        { status: 504 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Could not fetch the URL. The site may block server-side requests or be down." },
+      { status: 504 }
+    );
+  }
+
+  // Call Claude with text only — no tools
+  const client = new Anthropic();
+  let message: Anthropic.Message;
+  try {
+    const t0 = Date.now();
+    message = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      thinking: { type: "disabled" },
+      system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
+      messages: [
+        {
+          role: "user",
+          content: claudeInput,
+        },
+      ],
+    });
+    console.log("[parse-furniture] claude returned in", Date.now() - t0, "ms");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Claude API call failed.";
+    return NextResponse.json({ error: msg }, { status: 502 });
+  }
+
+  const textBlock = [...message.content]
+    .reverse()
+    .find((b): b is Anthropic.TextBlock => b.type === "text");
+
+  if (!textBlock) {
+    return NextResponse.json(
+      {
+        error:
+          "No text response from Claude. The page may not have been accessible or may require a login.",
+      },
+      { status: 422 }
+    );
+  }
+
+  let parsed: ParsedFurniture;
+  try {
+    const raw = textBlock.text;
+
+    const fenceStripped = raw
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```\s*$/i, "")
+      .trim();
+
+    try {
+      parsed = JSON.parse(fenceStripped);
+    } catch {
+      const first = raw.indexOf("{");
+      const last = raw.lastIndexOf("}");
+      if (first !== -1 && last > first) {
+        parsed = JSON.parse(raw.slice(first, last + 1));
+      } else {
+        throw new Error("no JSON object found");
+      }
+    }
+  } catch {
+    return NextResponse.json(
+      {
+        error:
+          "Claude could not extract furniture data from this page. Please confirm the URL points to a furniture product listing.",
+      },
+      { status: 422 }
+    );
+  }
+
+  if (!parsed.name || !Array.isArray(parsed.sizes) || parsed.sizes.length === 0) {
+    return NextResponse.json(
+      { error: "No useful furniture data was found on this page." },
+      { status: 422 }
+    );
+  }
+
+  const hallucinationPhrases = ["infer", "inferred", "training", "known product specifications", "from memory"];
+  const hasHallucination = Array.isArray(parsed.warnings) && parsed.warnings.some((w: string) =>
+    typeof w === "string" && hallucinationPhrases.some((p) => w.toLowerCase().includes(p))
+  );
+  if (hasHallucination) {
+    return NextResponse.json(
+      {
+        error: "The page content didn't include explicit dimensions and the model attempted to guess. The site may have rendered dimensions in JavaScript. Try a different URL or retailer.",
+        rawWarnings: parsed.warnings,
+      },
+      { status: 422 }
+    );
+  }
+
+  console.log("[parse-furniture] ok, sizes:", parsed.sizes.length);
+  return NextResponse.json(parsed);
+}

--- a/app/components/FurnitureUrlInput.tsx
+++ b/app/components/FurnitureUrlInput.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+
+type FurnitureSize = {
+  label: string;
+  widthIn: number | null;
+  depthIn: number | null;
+  heightIn: number | null;
+};
+
+type ParsedFurniture = {
+  name: string;
+  category: string;
+  sizes: FurnitureSize[];
+  defaultSizeIndex: number;
+  colorOrFinish?: string;
+  material?: string;
+  sourceUrl: string;
+  warnings: string[];
+};
+
+type FurnitureItem = {
+  id: string;
+  data: ParsedFurniture;
+  selectedSizeIndex: number;
+};
+
+function formatDimensions(size: FurnitureSize): string {
+  const { widthIn, depthIn, heightIn } = size;
+  if (widthIn == null && depthIn == null && heightIn == null) {
+    return "dimensions unknown";
+  }
+  const fmt = (n: number | null) => (n != null ? String(n) : "?");
+  return `${fmt(widthIn)} × ${fmt(depthIn)} × ${fmt(heightIn)} in`;
+}
+
+export default function FurnitureUrlInput() {
+  const [url, setUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<FurnitureItem[]>([]);
+
+  const handleAdd = async () => {
+    const trimmed = url.trim();
+    if (!trimmed || loading) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/parse-furniture", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: trimmed }),
+      });
+      const json = await res.json();
+
+      if (!res.ok) {
+        setError(json.error ?? "An unexpected error occurred.");
+      } else {
+        const data = json as ParsedFurniture;
+        setItems((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            data,
+            selectedSizeIndex: Math.max(
+              0,
+              Math.min(data.defaultSizeIndex ?? 0, data.sizes.length - 1)
+            ),
+          },
+        ]);
+        setUrl("");
+      }
+    } catch {
+      setError("Network error — could not reach the server.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const removeItem = (id: string) => {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updateSizeIndex = (id: string, index: number) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, selectedSizeIndex: index } : item
+      )
+    );
+  };
+
+  return (
+    <div className="w-full max-w-2xl">
+      <div className="flex gap-2">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleAdd();
+          }}
+          placeholder="Paste a furniture product URL — IKEA, Wayfair, Amazon, etc."
+          disabled={loading}
+          className="min-w-0 flex-1 rounded-xl border border-zinc-300 bg-white px-4 py-2.5 text-sm text-zinc-800 placeholder:text-zinc-400 focus:border-zinc-400 focus:outline-none disabled:opacity-50"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={loading || !url.trim()}
+          className="flex shrink-0 items-center gap-2 rounded-xl bg-zinc-800 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50"
+        >
+          {loading ? (
+            <>
+              <svg
+                className="h-4 w-4 shrink-0 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Adding…
+            </>
+          ) : (
+            "Add"
+          )}
+        </button>
+      </div>
+
+      <p className="mt-1 text-xs text-zinc-400">
+        Works best with IKEA, Article, CB2. Sites that load product data with JavaScript (West Elm, Pottery Barn, Wayfair, Amazon) may not parse — manual entry coming in a later update.
+      </p>
+
+      {error && (
+        <p className="mt-2 text-sm text-red-600">{error}</p>
+      )}
+
+      {items.length > 0 && (
+        <div className="mt-4 space-y-3">
+          {items.map((item) => {
+            const size =
+              item.data.sizes[item.selectedSizeIndex] ?? item.data.sizes[0];
+            const meta = [item.data.colorOrFinish, item.data.material]
+              .filter(Boolean)
+              .join(" · ");
+
+            return (
+              <div
+                key={item.id}
+                className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-zinc-800">
+                      {item.data.name}
+                    </p>
+                    <p className="mt-0.5 text-xs capitalize text-zinc-500">
+                      {item.data.category}
+                      {meta ? ` · ${meta}` : ""}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => removeItem(item.id)}
+                    aria-label="Remove item"
+                    className="shrink-0 rounded-full px-2 py-1 text-sm text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
+                  >
+                    ✕
+                  </button>
+                </div>
+
+                <div className="mt-3">
+                  {item.data.sizes.length > 1 ? (
+                    <div className="flex items-center gap-3">
+                      <label className="shrink-0 text-xs font-medium text-zinc-500">
+                        Size
+                      </label>
+                      <select
+                        value={item.selectedSizeIndex}
+                        onChange={(e) =>
+                          updateSizeIndex(item.id, Number(e.target.value))
+                        }
+                        className="flex-1 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm text-zinc-700 focus:border-zinc-400 focus:outline-none"
+                      >
+                        {item.data.sizes.map((s, i) => (
+                          <option key={i} value={i}>
+                            {s.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : (
+                    <p className="text-xs text-zinc-500">{size.label}</p>
+                  )}
+                  <p className="mt-1.5 font-mono text-sm text-zinc-700">
+                    {formatDimensions(size)}
+                  </p>
+                </div>
+
+                {item.data.warnings.length > 0 && (
+                  <div className="mt-3 rounded-lg border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800">
+                    {item.data.warnings.join(" · ")}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,19 @@
 import FloorPlanUploader from "./components/FloorPlanUploader";
+import FurnitureUrlInput from "./components/FurnitureUrlInput";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-zinc-50 px-4 py-16">
+    <main className="flex min-h-screen flex-col items-center bg-zinc-50 px-4 py-16">
       <div className="mb-10 text-center">
         <h1 className="text-3xl font-bold tracking-tight text-zinc-900">apartment fit</h1>
         <p className="mt-2 text-zinc-500">Upload a floor plan to get started</p>
       </div>
       <FloorPlanUploader />
+      <div className="w-full max-w-2xl">
+        <hr className="my-8 border-zinc-200" />
+        <h2 className="mb-4 text-lg font-semibold text-zinc-700">Add furniture</h2>
+        <FurnitureUrlInput />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
   Closes #3.

   Adds a furniture URL handler that fetches the product page server-side and extracts dimensions via Claude. Multi-tier extraction: Schema.org JSON-LD Product data first, then SPA initial-state scripts (__NEXT_DATA__, __APOLLO_STATE__, etc.), falling back to cleaned body HTML. Supports multi-variant products (different sizes per product) — UI shows a size dropdown when more than one variant is detected.

   Anti-hallucination guard: post-validation rejects responses where the model attempted to infer dimensions from training data instead of from the page content.

   Tested working:
   - ✓ IKEA (multi-variant)
   - ✓ Article

   Known limitations (deferred to #8 manual-entry fallback):
   - West Elm / Pottery Barn / Williams-Sonoma — React/Apollo SPAs with no initial product data
   - Wayfair, Amazon — client-side rendering + anti-scraping